### PR TITLE
feat(users): add validation for user routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.DS_Store
+/dist
+/build
+

--- a/src/server/api-routes.js
+++ b/src/server/api-routes.js
@@ -6,6 +6,7 @@ const { User, Group, Parameter, Currency, Country, Language, DateFormat, NumberF
 const bcrypt = require('bcrypt');
 const crypto = require('crypto');
 const { Op } = Sequelize;
+const { validateCreateUser, validateUpdateUser } = require('./validators/userSchemas');
 
 // Middleware pour gérer les erreurs
 const asyncHandler = fn => (req, res, next) => {
@@ -59,7 +60,7 @@ router.get('/users/:id', asyncHandler(async (req, res) => {
   res.json(transformedUser);
 }));
 
-router.post('/users', asyncHandler(async (req, res) => {
+router.post('/users', validateCreateUser, asyncHandler(async (req, res) => {
   const { username, email, password, firstName, lastName, role, status, groups } = req.body;
 
   // Hacher le mot de passe
@@ -106,7 +107,7 @@ router.post('/users', asyncHandler(async (req, res) => {
   res.status(201).json(transformedUser);
 }));
 
-router.put('/users/:id', asyncHandler(async (req, res) => {
+router.put('/users/:id', validateUpdateUser, asyncHandler(async (req, res) => {
   const { username, email, password, firstName, lastName, role, status, groups } = req.body;
 
   const user = await User.findByPk(req.params.id);

--- a/src/server/validators/userSchemas.js
+++ b/src/server/validators/userSchemas.js
@@ -1,0 +1,28 @@
+const { z } = require('zod');
+
+const createUserSchema = z.object({
+  username: z.string().min(1, { message: 'username is required' }),
+  email: z.string().email({ message: 'invalid email' }),
+  password: z.string().min(6, { message: 'password must be at least 6 characters' }),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  role: z.string().optional(),
+  status: z.string().optional(),
+  groups: z.array(z.string()).optional()
+});
+
+const updateUserSchema = createUserSchema.partial();
+
+const validate = (schema) => (req, res, next) => {
+  const result = schema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ errors: result.error.errors });
+  }
+  req.body = result.data;
+  next();
+};
+
+module.exports = {
+  validateCreateUser: validate(createUserSchema),
+  validateUpdateUser: validate(updateUserSchema)
+};


### PR DESCRIPTION
## Summary
- validate user creation and update payloads with Zod
- return 400 with detailed errors when user data is invalid
- ignore node_modules directory

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint config uses ESM import not supported)


------
https://chatgpt.com/codex/tasks/task_e_689cbab31cdc832d95824fc92f60d89f