### PR TITLE
feat: add conditional logger

### DIFF
--- a/src/server/api-routes.js
+++ b/src/server/api-routes.js
@@ -6,6 +6,7 @@ const { User, Group, Parameter, Currency, Country, Language, DateFormat, NumberF
 const bcrypt = require('bcrypt');
 const crypto = require('crypto');
 const { Op } = Sequelize;
+const logger = require('./logger');
 
 // Middleware pour gérer les erreurs
 const asyncHandler = fn => (req, res, next) => {
@@ -985,13 +986,13 @@ router.get('/dateformats/:id', asyncHandler(async (req, res) => {
 }));
 
 router.post('/dateformats', asyncHandler(async (req, res) => {
-  console.log('POST /dateformats - Données reçues:', req.body);
+  logger.info('POST /dateformats');
 
   const { name, format, description, type, is_default, active } = req.body;
 
   // Vérifier les données requises
   if (!name || !format || !type) {
-    console.log('Données manquantes:', { name, format, type });
+    logger.warn('POST /dateformats - données manquantes');
     return res.status(400).json({ message: 'Les champs name, format et type sont requis' });
   }
 
@@ -1001,7 +1002,7 @@ router.post('/dateformats', asyncHandler(async (req, res) => {
   });
 
   if (existingFormat) {
-    console.log('Format existant:', existingFormat.format);
+    logger.warn('POST /dateformats - format existant');
     return res.status(400).json({ message: 'Un format avec ce motif existe déjà' });
   }
 
@@ -1038,13 +1039,13 @@ router.post('/dateformats', asyncHandler(async (req, res) => {
 }));
 
 router.put('/dateformats/:id', asyncHandler(async (req, res) => {
-  console.log('PUT /dateformats/:id - Données reçues:', req.body);
+  logger.info('PUT /dateformats/:id');
 
   const { name, format, description, type, is_default, active } = req.body;
 
   // Vérifier les données requises
   if (!name || !format || !type) {
-    console.log('Données manquantes:', { name, format, type });
+    logger.warn('PUT /dateformats/:id - données manquantes');
     return res.status(400).json({ message: 'Les champs name, format et type sont requis' });
   }
 
@@ -1216,13 +1217,13 @@ router.get('/translations/:id', asyncHandler(async (req, res) => {
 }));
 
 router.post('/translations', asyncHandler(async (req, res) => {
-  console.log('POST /translations - Données reçues:', req.body);
+  logger.info('POST /translations');
 
     const { key, locale, namespace, value, is_default, active, description } = req.body;
 
   // Vérifier les données requises
   if (!key || !locale || !value) {
-    console.log('Données manquantes:', { key, locale, value });
+    logger.warn('POST /translations - données manquantes');
     return res.status(400).json({ message: 'Les champs key, locale et value sont requis' });
   }
 
@@ -1236,7 +1237,7 @@ router.post('/translations', asyncHandler(async (req, res) => {
   });
 
   if (existingTranslation) {
-    console.log('Traduction existante:', existingTranslation.key);
+    logger.warn('POST /translations - traduction existante');
     return res.status(400).json({ message: 'Une traduction avec cette clé, cette locale et cet espace de noms existe déjà' });
   }
 
@@ -1269,13 +1270,13 @@ router.post('/translations', asyncHandler(async (req, res) => {
 }));
 
 router.put('/translations/:id', asyncHandler(async (req, res) => {
-  console.log('PUT /translations/:id - Données reçues:', req.body);
+  logger.info('PUT /translations/:id');
 
   const { key, locale, namespace, value, is_default, active, description } = req.body;
 
   // Vérifier les données requises
   if (!key || !locale || !value) {
-    console.log('Données manquantes:', { key, locale, value });
+    logger.warn('PUT /translations/:id - données manquantes');
     return res.status(400).json({ message: 'Les champs key, locale et value sont requis' });
   }
 
@@ -2245,7 +2246,7 @@ router.get('/securitysettings', asyncHandler(async (req, res) => {
       try {
         parsedValue = JSON.parse(setting.value);
       } catch (error) {
-        console.error(`Erreur lors de l'analyse JSON pour ${setting.key}:`, error);
+        logger.error("Erreur lors de l'analyse JSON");
       }
     }
 
@@ -2279,7 +2280,7 @@ router.get('/securitysettings/category/:category', asyncHandler(async (req, res)
       try {
         parsedValue = JSON.parse(setting.value);
       } catch (error) {
-        console.error(`Erreur lors de l'analyse JSON pour ${setting.key}:`, error);
+        logger.error("Erreur lors de l'analyse JSON");
       }
     }
 
@@ -2315,7 +2316,7 @@ router.get('/securitysettings/key/:key', asyncHandler(async (req, res) => {
     try {
       parsedValue = JSON.parse(securitySetting.value);
     } catch (error) {
-      console.error(`Erreur lors de l'analyse JSON pour ${securitySetting.key}:`, error);
+      logger.error("Erreur lors de l'analyse JSON");
     }
   }
 
@@ -2366,7 +2367,7 @@ router.put('/securitysettings/key/:key', asyncHandler(async (req, res) => {
     try {
       parsedValue = JSON.parse(securitySetting.value);
     } catch (error) {
-      console.error(`Erreur lors de l'analyse JSON pour ${securitySetting.key}:`, error);
+      logger.error("Erreur lors de l'analyse JSON");
     }
   }
 
@@ -2417,7 +2418,7 @@ router.put('/securitysettings/batch', asyncHandler(async (req, res) => {
         try {
           parsedValue = JSON.parse(securitySetting.value);
         } catch (error) {
-          console.error(`Erreur lors de l'analyse JSON pour ${securitySetting.key}:`, error);
+          logger.error("Erreur lors de l'analyse JSON");
         }
       }
 
@@ -2860,7 +2861,7 @@ router.get('/loggingsettings', asyncHandler(async (req, res) => {
       try {
         value = JSON.parse(value);
       } catch (e) {
-        console.error(`Erreur lors de la conversion JSON pour ${setting.key}:`, e);
+        logger.error('Erreur lors de la conversion JSON');
       }
     }
 
@@ -2896,7 +2897,7 @@ router.get('/loggingsettings/:key', asyncHandler(async (req, res) => {
     try {
       value = JSON.parse(value);
     } catch (e) {
-      console.error(`Erreur lors de la conversion JSON pour ${setting.key}:`, e);
+      logger.error('Erreur lors de la conversion JSON');
     }
   }
 
@@ -2949,7 +2950,7 @@ router.put('/loggingsettings/:key', asyncHandler(async (req, res) => {
     try {
       convertedValue = JSON.parse(convertedValue);
     } catch (e) {
-      console.error(`Erreur lors de la conversion JSON pour ${setting.key}:`, e);
+      logger.error('Erreur lors de la conversion JSON');
     }
   }
 
@@ -3002,7 +3003,7 @@ router.put('/loggingsettings/batch', asyncHandler(async (req, res) => {
         try {
           convertedValue = JSON.parse(convertedValue);
         } catch (e) {
-          console.error(`Erreur lors de la conversion JSON pour ${setting.key}:`, e);
+          logger.error('Erreur lors de la conversion JSON');
         }
       }
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -5,6 +5,7 @@ const bodyParser = require('body-parser');
 const cors = require('cors');
 const apiRoutes = require('./api-routes');
 const { sequelize } = require('../models');
+const logger = require('./logger');
 
 // Créer l'application Express
 const app = express();
@@ -19,7 +20,7 @@ app.use('/api', apiRoutes);
 
 // Gestion des erreurs
 app.use((err, req, res, next) => {
-  console.error(err.stack);
+  logger.error(err.message);
   res.status(500).json({
     message: 'Une erreur est survenue',
     error: process.env.NODE_ENV === 'development' ? err.message : undefined
@@ -33,14 +34,14 @@ async function startServer() {
   try {
     // Vérifier la connexion à la base de données
     await sequelize.authenticate();
-    console.log('Connexion à la base de données établie avec succès.');
-    
+    logger.info('Connexion à la base de données établie avec succès.');
+
     // Démarrer le serveur
     app.listen(PORT, () => {
-      console.log(`Serveur démarré sur le port ${PORT}`);
+      logger.info(`Serveur démarré sur le port ${PORT}`);
     });
   } catch (error) {
-    console.error('Impossible de se connecter à la base de données:', error);
+    logger.error('Impossible de se connecter à la base de données');
     process.exit(1);
   }
 }

--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const isProd = process.env.NODE_ENV === 'production';
+
+function log(method, message) {
+  if (isProd) return;
+  console[method](message);
+}
+
+module.exports = {
+  info: (msg) => log('log', msg),
+  warn: (msg) => log('warn', msg),
+  error: (msg) => log('error', msg),
+};

--- a/src/setup-db.js
+++ b/src/setup-db.js
@@ -3,6 +3,7 @@
 const { sequelize } = require('./models');
 const { exec } = require('child_process');
 const path = require('path');
+const logger = require('./server/logger');
 
 /**
  * Script pour initialiser la base de données
@@ -10,53 +11,45 @@ const path = require('path');
  */
 async function setupDatabase() {
   try {
-    console.log('Démarrage de l\'initialisation de la base de données...');
+    logger.info("Démarrage de l'initialisation de la base de données...");
     
     // Vérifier la connexion à la base de données
     try {
       await sequelize.authenticate();
-      console.log('Connexion à la base de données établie avec succès.');
+      logger.info('Connexion à la base de données établie avec succès.');
     } catch (error) {
-      console.error('Impossible de se connecter à la base de données:', error);
+      logger.error("Impossible de se connecter à la base de données");
       process.exit(1);
     }
     
     // Exécuter les migrations
-    console.log('Exécution des migrations...');
+    logger.info('Exécution des migrations...');
     await new Promise((resolve, reject) => {
       exec('npx sequelize-cli db:migrate --migrations-path=src/migrations', (error, stdout, stderr) => {
         if (error) {
-          console.error(`Erreur lors de l'exécution des migrations: ${error.message}`);
+          logger.error("Erreur lors de l'exécution des migrations");
           return reject(error);
         }
-        if (stderr) {
-          console.error(`stderr: ${stderr}`);
-        }
-        console.log(`stdout: ${stdout}`);
         resolve();
       });
     });
     
     // Exécuter les seeds
-    console.log('Exécution des seeds...');
+    logger.info('Exécution des seeds...');
     await new Promise((resolve, reject) => {
       exec('npx sequelize-cli db:seed:all --seeders-path=src/seeders', (error, stdout, stderr) => {
         if (error) {
-          console.error(`Erreur lors de l'exécution des seeds: ${error.message}`);
+          logger.error("Erreur lors de l'exécution des seeds");
           return reject(error);
         }
-        if (stderr) {
-          console.error(`stderr: ${stderr}`);
-        }
-        console.log(`stdout: ${stdout}`);
         resolve();
       });
     });
     
-    console.log('Initialisation de la base de données terminée avec succès!');
+    logger.info('Initialisation de la base de données terminée avec succès!');
     process.exit(0);
   } catch (error) {
-    console.error('Erreur lors de l\'initialisation de la base de données:', error);
+    logger.error("Erreur lors de l'initialisation de la base de données");
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- add simple logger utility that silences output in production
- use logger across server startup, API routes and DB setup to avoid leaking sensitive data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot use import statement outside a module)


------
https://chatgpt.com/codex/tasks/task_e_689cbab372c8832da4c045a363937da7