### PR TITLE
feat: make API URL configurable

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:3001/api
+VITE_API_BASE_URL=http://localhost:3000/api

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VITE_API_BASE_URL=http://localhost:3001/api
+VITE_API_BASE_URL=http://localhost:3000/api
 PORT=3001
 DB_USERNAME=
 DB_PASSWORD=

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 // Configuration de base d'axios
 const api = axios.create({
-  baseURL: 'http://164.160.40.182:3001/api',
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api',
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Summary
- allow API client to use configurable base URL via `VITE_API_BASE_URL`
- document `VITE_API_BASE_URL` in example environment files

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689cc9566c14832dbbd82b0dc3923325