### PR TITLE
docs: préciser Node 18 comme prérequis

### DIFF
--- a/README-DEMARRAGE.md
+++ b/README-DEMARRAGE.md
@@ -4,7 +4,7 @@ Ce document explique comment démarrer l'application avec toutes ses migrations 
 
 ## Prérequis
 
-- Node.js (version 14 ou supérieure)
+- Node.js 18 (ou une version plus récente compatible avec les dépendances). L'utilisation d'une version antérieure n'est pas recommandée.
 - npm (généralement installé avec Node.js)
 
 ## Scripts de Démarrage


### PR DESCRIPTION
## Summary
- demander Node.js 18 ou version supportée par les dépendances dans README-DEMARRAGE

## Testing
- `npm test` *(échoue : Missing script: "test")*
- `npm run lint` *(échoue : Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689d40939ab8832d8f9e51598d49f32b